### PR TITLE
Task / Refactor twitchie-timer component

### DIFF
--- a/dashboard/twitchie-timer/twitchie-countdown.html
+++ b/dashboard/twitchie-timer/twitchie-countdown.html
@@ -1,0 +1,50 @@
+<link rel="import" href="/bundles/nodecg-twitchie-graphics/bower_components/polymer/polymer-element.html">
+<link rel="import" href="/bundles/nodecg-twitchie-graphics/bower_components/iron-icons/iron-icons.html">
+<link rel="import" href="/bundles/nodecg-twitchie-graphics/bower_components/iron-icons/image-icons.html">
+
+<dom-module id="twitchie-countdown">
+  <link href="/bundles/nodecg-twitchie/dashboard/styles/base.css" rel="import" type="css">
+
+  <template>
+    <style>
+      .c-timer-target {
+        margin: 0 auto 1rem;
+      }
+
+      .c-timer-countdown {
+        display: flex;
+        flex-flow: row nowrap;
+        align-items: center;
+        justify-content: center;
+
+        margin: 0 auto 1rem;
+        font-size: 2em;
+      }
+
+      .c-timer-countdown iron-icon {
+        margin: 0 0.5em 0 0;
+      }
+    </style>
+
+    <div class="c-timer-target">
+      The timer has been set for
+
+      <output id="target">
+        {{targetText}}
+      </output>.
+    </div>
+
+    <div class="c-timer-countdown">
+      <iron-icon
+        icon="image:timer"
+      ></iron-icon>
+
+      <output id="countdown">
+        {{countdownText}}
+      </output>
+    </div>
+  </template>
+
+  <script src="/bundles/nodecg-twitchie-graphics/bower_components/moment/moment.js"></script>
+  <script src="twitchie-countdown.js"></script>
+</dom-module>

--- a/dashboard/twitchie-timer/twitchie-countdown.js
+++ b/dashboard/twitchie-timer/twitchie-countdown.js
@@ -1,0 +1,56 @@
+/* global nodecg, NodeCG, moment, Polymer */
+
+const getCountdownText = (diff) => {
+  if (diff <= 0) {
+    return 'Finished!'
+  }
+
+  const diffMoment = moment.utc(diff)
+
+  return diffMoment.format(
+    diffMoment.hours() > 0
+      ? 'H:mm:ss'
+      : 'm:ss'
+  )
+}
+
+class TwitchieCountdown extends Polymer.Element {
+  static get is() {
+    return 'twitchie-countdown'
+  }
+
+  static get properties() {
+    return {
+      target: {
+        type: Number,
+        value: 0,
+        observer: 'updateTimer',
+      },
+    }
+  }
+
+  tick() {
+    const now = moment.utc()
+    const diff = this.targetMoment.diff(now)
+    this.countdownText = getCountdownText(diff)
+  }
+
+  updateTimer(newTarget) {
+    clearTimeout(this.tickTimer)
+
+    if (!newTarget) {
+      return
+    }
+
+    this.targetMoment = moment.utc(newTarget)
+    this.targetText = this.targetMoment.local().format('LTS, on LL')
+
+    this.tick()
+    this.tickTimer = setInterval(
+      () => this.tick(),
+      1 * 1000,
+    )
+  }
+}
+
+customElements.define(TwitchieCountdown.is, TwitchieCountdown)

--- a/dashboard/twitchie-timer/twitchie-timer.html
+++ b/dashboard/twitchie-timer/twitchie-timer.html
@@ -5,30 +5,12 @@
 <link rel="import" href="/bundles/nodecg-twitchie-graphics/bower_components/paper-input/paper-input.html">
 <link rel="import" href="/bundles/nodecg-twitchie-graphics/bower_components/paper-button/paper-button.html">
 
+<link rel="import" href="twitchie-countdown.html">
+
 <dom-module id="twitchie-timer">
   <link href="/bundles/nodecg-twitchie/dashboard/styles/base.css" rel="import" type="css">
 
   <template>
-    <style>
-      .c-timer-target {
-        margin: 0 auto 1rem;
-      }
-
-      .c-timer-countdown {
-        display: flex;
-        flex-flow: row nowrap;
-        align-items: center;
-        justify-content: center;
-
-        margin: 0 auto 1rem;
-        font-size: 2em;
-      }
-
-      .c-timer-countdown iron-icon {
-        margin: 0 0.5em 0 0;
-      }
-    </style>
-
     <iron-pages
       id="pages"
       selected="create"
@@ -73,23 +55,7 @@
       </section>
 
       <section name="manage">
-        <div class="c-timer-target">
-          The timer has been set for
-
-          <output id="target">
-            00:00
-          </output>.
-        </div>
-
-        <div class="c-timer-countdown">
-          <iron-icon
-            icon="image:timer"
-          ></iron-icon>
-
-          <output id="countdown">
-            00:00:00
-          </output>
-        </div>
+        <twitchie-countdown target="[[timer]]"></twitchie-countdown>
 
         <paper-button
           raised

--- a/dashboard/twitchie-timer/twitchie-timer.js
+++ b/dashboard/twitchie-timer/twitchie-timer.js
@@ -2,20 +2,6 @@
 
 const timer = nodecg.Replicant('timer', 'nodecg-twitchie')
 
-const getCountdownText = (diff) => {
-  if (diff <= 0) {
-    return 'Finished!'
-  }
-
-  const diffMoment = moment.utc(diff)
-
-  return diffMoment.format(
-    diffMoment.hours() > 0
-      ? 'H:mm:ss'
-      : 'm:ss'
-  )
-}
-
 class TwitchieTimer extends Polymer.Element {
   static get is() {
     return 'twitchie-timer'
@@ -45,28 +31,6 @@ class TwitchieTimer extends Polymer.Element {
     timer.value = newTimer.utc()
   }
 
-  createCountdownTicker(target) {
-    const targetMoment = moment.utc(target)
-    this.$.target.innerHTML = targetMoment.local().format('LTS, on LL')
-
-    return () => {
-      const now = moment.utc()
-      const diff = targetMoment.diff(now)
-
-      this.$.countdown.innerHTML = getCountdownText(diff)
-    }
-  }
-
-  startCountdownTo(target) {
-    const tick = this.createCountdownTicker(target)
-    tick()
-
-    return setInterval(
-      tick,
-      1 * 1000,
-    )
-  }
-
   async ready() {
     super.ready()
     await NodeCG.waitForReplicants(timer)
@@ -74,20 +38,10 @@ class TwitchieTimer extends Polymer.Element {
     timer.on(
       'change',
       (newVal) => {
+        this.timer = newVal
         this.$.pages.selected = newVal
           ? 'manage'
           : 'create'
-      }
-    )
-
-    timer.on(
-      'change',
-      (newVal) => {
-        if (newVal) {
-          this.tickTimeout = this.startCountdownTo(newVal)
-        } else {
-          clearTimeout(this.tickTimeout)
-        }
       }
     )
   }


### PR DESCRIPTION
This PR splits countdown display logic out of twitchie-timer into its own component, twitchie-countdown. This lets us leverage Polymer's inbuilt events and binding stuff a little bit better, and kinda just clarify the structure of things